### PR TITLE
Adds the Spreadsheets.tables([ranges]) that receives an array of sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,62 @@ For now, node-sheets offers two authentication mechanisms.
 ## Other API Methods
 
 - `Sheets.getLastUpdateDate()`: Returns a ISO_8601 compatible string with the last update date of the spreadsheet.
+- `Sheets.getSheetsNames()`: Returns a list with all the names of the sheets in the spreadsheet.
+- `Sheets.tables(rangeArray)`: Returns array of #table information for each range specified. Note that you may need to append `!A:ZZZ` to the end of your sheet name, if the name use a syntax compatible with a range (ex: A100). More info [here](http://stackoverflow.com/a/39641586).
 
-- `Sheets.getSheetsNames()`: Returns a list with all the names of the sheets in the spreadsheet
+## Reponse schema for `.table(range)` / `.tables(ranges)`
+
+Returns a spreadsheet range in tabular row format. The tabular row format returns the content by rows, and each row contains the values for each column.
+
+### Sample
+
+| Header 1   | Header 2 | Header 3 |
+| ---------- | -------- | -------- |
+| row 1 text | $0.41    | 3.00     |
+| ...        | ...      | ...      |
+
+```javascript
+const table = await gs.table('Formats')
+
+{
+ title: 'Formats',                                                        // name of the sheet/table
+ headers: ['Header 1', 'Header 2', 'Header 3'],                           // name of the headers (1st row)
+ formats: [                                                               // array with information regarding cell format
+   { numberFormat: { type: 'NONE' } },
+   { numberFormat: { type: 'CURRENCY', pattern: '"$"#,##0.00' } },
+   { numberFormat: { type: 'NUMBER', pattern: '#,##0.00' } } ]
+ rows: [                                                                  // rows contains the values for 2nd row ahead
+   {                                                                      // Each row object has:
+     cols: {                                                                  // cols - map header -> (value | stringValue)
+       'Header 1': { value: 'row 1 text', stringValue: 'row 1 text' },
+       'Header 2': { value: 0.41, stringValue: '$0.41' },
+       'Header 3': { value: 3, stringValue: '3.00' }
+      },
+      values: ['row 1 text', 0.41, 3],                                        // values - array with values for each header
+      stringValue: ['row 1 text', '$0.41', '3.00']                            // stringValue - string representation of the values for each header
+    },
+   { ... },
+   { ... }
+ ]
+}
+```
+
+Sample access to the value of col 'Header 2' of first row:
+
+```javascript
+const currencyValue = table.rows[0].cols['Header 2'].value     // 0.41
+```
+
+It is also possible to get an array with all the (column) values for the row (formatted and string versions):
+
+```javascript
+const rowValues = table.rows[0].values              // [..., ..., ...]
+const rowValues = table.rows[0].stringValues        // ['...', '...', ...]
+```
+
+
+**Note:** Formats are retrieved from first data row.
+
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-runtime": "^6.11.6",
     "google-auth-library": "^0.9.8",
     "googleapis": "^12.4.0",
+    "lodash.zipobject": "^4.1.3",
     "q": "^1.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sheets",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Utility Wrapper for Google Spreadsheets",
   "author": "Carlos Guedes <carlos@urbancups.com> (http://cupsapp.com)",
   "scripts": {

--- a/src/sheets.js
+++ b/src/sheets.js
@@ -1,6 +1,7 @@
 import Q from 'q'
 import google from 'googleapis'
 import util from 'util'
+import zipObject from 'lodash.zipobject'
 
 export default class Sheets {
 
@@ -60,6 +61,9 @@ export default class Sheets {
     return res.modifiedTime
   }
 
+  /**
+   * Returns a list with all the names of the sheets in the spreadsheet.
+   */
   async getSheetsNames () {
     var sheets = google.sheets('v4')
     const response = await Q.ninvoke(sheets.spreadsheets, "get", {
@@ -85,8 +89,7 @@ export default class Sheets {
    * Note: Formats are retrieved from first data row.
    */
   async tableCols (range) {
-    const spreadsheet = await getRange(this.auth, this.spreadsheetId, range)
-
+    const spreadsheet = await getRanges(this.auth, this.spreadsheetId, [range])
     const sheet = spreadsheet.sheets[0] // first (unique) sheet
     const gridData = sheet.data[0]  // first (unique) range
     const headers = gridData.rowData[0].values // first row (headers)
@@ -126,26 +129,93 @@ export default class Sheets {
    * Note: Formats are retrieved from first data row.
    */
   async table (range) {
-    const spreadsheet = await getRange(this.auth, this.spreadsheetId, range)
-
-    const sheet = spreadsheet.sheets[0] // first (unique) sheet
-    const gridData = sheet.data[0]  // first (unique) range
-    const headers = gridData.rowData[0].values // first row (headers)
-                            .map(col => formattedValue(col))
-
-    const otherRows = gridData.rowData.slice(1)
-
-    return {
-      headers: headers,
-      formats: otherRows[0].values.map(value => effectiveFormat(value)),
-      rows: otherRows.map(row => ({
-        values: row.values.map(value => effectiveValue(value)),
-        stringValues: row.values.map(value => formattedValue(value))
-      }))
-    }
+    const tables = await this.tables([range])
+    return tables[0]
   }
 
+  /**
+   * Returns an array with tables with tabular content of the requests ranges.
+   */
+  async tables (ranges) {
+    const spreadsheets = await getRanges(this.auth, this.spreadsheetId, ranges)
+    return spreadsheets.sheets.map(sheetToTable)
+  }
 
+}
+
+
+/**
+ * Returns a spreadsheet range in tabular row format.
+ * The tabular row format returns the content by rows, and each row contains the values for each column.
+ *
+ * | Header 1   | Header 2 | Header 3 |
+ * | ---------- | -------- | -------- |
+ * | row 1 text | $0.41    | 3.00     |
+ * | ...        | ...      | ...      |
+ *
+ *
+ * {
+ *  title: 'Formats',                                                        // name of the sheet/table
+ *  headers: ['Header 1', 'Header 2', 'Header 3'],                           // name of the headers (1st row)
+ *  formats: [                                                               // array with information regarding cell format
+ *    { numberFormat: { type: 'NONE' } },
+ *    { numberFormat: { type: 'CURRENCY', pattern: '"$"#,##0.00' } },
+ *    { numberFormat: { type: 'NUMBER', pattern: '#,##0.00' } } ]
+ *  rows: [                                                                  // rows contains the values for 2nd row ahead
+ *    {                                                                      // Each row object has:
+ *      cols: {                                                                  // cols - map header -> (value | stringValue)
+ *        'Header 1': { value: 'row 1 text', stringValue: 'row 1 text' },
+ *        'Header 2': { value: 0.41, stringValue: '$0.41' },
+ *        'Header 3': { value: 3, stringValue: '3.00' }
+ *       },
+ *       values: ['row 1 text', 0.41, 3],                                        // values - array with values for each header
+ *       stringValue: ['row 1 text', '$0.41', '3.00']                            // stringValue - string representation of the values for each header
+ *     },
+ *    { ... },
+ *    { ... }
+ *  ]
+ * }
+ *
+ * Sample access to the value of col 'Header 2' of first row:
+ * ```
+ * const currencyValue = table.rows[0].cols['Header 2'].value     // 0.41
+ * ```
+ *
+ * It is also possible to get an array with all the (column) values for the row (formatted and string versions):
+ * ```
+ * const rowValues = table.rows[0].values              // ['row 1 text', 0.41, 3]
+ * const rowValues = table.rows[0].stringValues        // ['row 1 text', '$0.41', '3.00']
+ * ```
+ *
+ *
+ * Note: Formats are retrieved from first data row.
+ */
+function sheetToTable (sheet) {
+  if (sheet.data.length === 0 || sheet.data[0].rowData === undefined) {
+    return {
+      title: sheet.properties.title,
+      headers: [],
+      formats: [],
+      rows: []
+    }
+  }
+  const gridData = sheet.data[0]  // first (unique) range
+  const headers = gridData.rowData[0].values // first row (headers)
+                          .map(col => formattedValue(col))
+
+  const otherRows = gridData.rowData.slice(1)
+
+  return {
+    title: sheet.properties.title,
+    headers: headers,
+    formats: otherRows[0].values.map(value => effectiveFormat(value)),
+    rows: otherRows.map(row => ({
+      cols: zipObject(headers,
+                      row.values.map(value => ({ value: effectiveValue(value), stringValue: formattedValue(value)}))),
+      values: row.values.map(value => effectiveValue(value)),
+      stringValues: row.values.map(value => formattedValue(value))
+    }))
+  }
 }
 
 function formattedValue (value) {
@@ -209,10 +279,10 @@ function ExcelDateToJSDate(serial) {
 /**
  * Utility function to get a range from a spreadsheet
  */
-async function getRange (
+async function getRanges (
   auth,
   spreadsheetId,
-  range,
+  ranges,
   fields = 'properties.title,sheets.properties,sheets.data(rowData.values.effectiveValue,rowData.values.formattedValue,rowData.values.effectiveFormat.numberFormat)'
 ) {
   var sheets = google.sheets('v4')
@@ -222,7 +292,7 @@ async function getRange (
     // https://developers.google.com/sheets/guides/concepts, https://developers.google.com/sheets/samples/sheet
     fields: fields,
     includeGridData: true,
-    ranges: [range],
+    ranges: ranges,
   })
   const spreadsheet = response[0]
   return spreadsheet

--- a/src/sheets.js
+++ b/src/sheets.js
@@ -109,86 +109,69 @@ export default class Sheets {
   }
 
   /**
-   * Returns a spreadsheet range in tabular row format.
+   * Returns spreadsheet ranges in tabular row format.
    * The tabular row format returns the content by rows, and each row contains the values for each column.
    *
+   * | Header 1   | Header 2 | Header 3 |
+   * | ---------- | -------- | -------- |
+   * | row 1 text | $0.41    | 3.00     |
+   * | ...        | ...      | ...      |
+   *
+   *
    * {
-   *  headers: ['Header 1', 'Header 2', 'Header 3'],
-   *  formats: [
+   *  title: 'Formats',                                                        // name of the sheet/table
+   *  headers: ['Header 1', 'Header 2', 'Header 3'],                           // name of the headers (1st row)
+   *  formats: [                                                               // array with information regarding cell format
    *    { numberFormat: { type: 'NONE' } },
    *    { numberFormat: { type: 'CURRENCY', pattern: '"$"#,##0.00' } },
    *    { numberFormat: { type: 'NUMBER', pattern: '#,##0.00' } } ]
-   *  rows: [
-   *    { values: ['some text', 0.41, 3], stringValues: ['some text', '$0.41', '3.00' ] },
-   *    { values: ['some text', 0.41, 3], stringValues: ['some text', '$0.41', '3.00' ] },
-   *    { values: ['some text', 0.41, 3], stringValues: ['some text', '$0.41', '3.00' ] },
-   *    { values: ['some text', 0.41, 3], stringValues: ['some text', '$0.41', '3.00' ] }
+   *  rows: [                                                                  // rows contains the values for 2nd row ahead
+   *    {                                                                      // Each row object has:
+  *        'Header 1': { value: 'row 1 text', stringValue: 'row 1 text' },
+  *        'Header 2': { value: 0.41, stringValue: '$0.41' },
+  *        'Header 3': { value: 3, stringValue: '3.00' }
+   *     },
+   *    { ... },
+   *    { ... }
    *  ]
    * }
    *
+   * Sample access to the value of col 'Header 2' of first row:
+   * ```
+   * const currencyValue = table.rows[0]['Header 2'].value     // 0.41
+   * ```
+   *
    * Note: Formats are retrieved from first data row.
    */
-  async table (range) {
-    const tables = await this.tables([range])
-    return tables[0]
-  }
-
-  /**
-   * Returns an array with tables with tabular content of the requests ranges.
-   */
   async tables (ranges) {
+    let single = false
+    if (typeof ranges === 'string') {
+      // string
+      ranges = [ { name: ranges } ] // NOTE: This version doesn't add range `A:ZZZ`
+      single = true
+    }
+    else if (Array.isArray(ranges) === false) {
+      // object
+      ranges = [ { name: ranges.name, range: ranges.range || 'A:ZZZ' } ]
+    }
+    else {
+      // Array
+      ranges = ranges.map(range => ({ name: range.name, range: range.range || 'A:ZZZ' }))
+    }
+
+    // convert ranges to google-sheets ranges
+    ranges = ranges.map(r => `${r.name}${r.range ? `!${r.range}`:''}`)
+
     const spreadsheets = await getRanges(this.auth, this.spreadsheetId, ranges)
-    return spreadsheets.sheets.map(sheetToTable)
+    const res = spreadsheets.sheets.map(sheetToTable)
+    return single ? res[0] : res
   }
 
 }
 
 
 /**
- * Returns a spreadsheet range in tabular row format.
- * The tabular row format returns the content by rows, and each row contains the values for each column.
- *
- * | Header 1   | Header 2 | Header 3 |
- * | ---------- | -------- | -------- |
- * | row 1 text | $0.41    | 3.00     |
- * | ...        | ...      | ...      |
- *
- *
- * {
- *  title: 'Formats',                                                        // name of the sheet/table
- *  headers: ['Header 1', 'Header 2', 'Header 3'],                           // name of the headers (1st row)
- *  formats: [                                                               // array with information regarding cell format
- *    { numberFormat: { type: 'NONE' } },
- *    { numberFormat: { type: 'CURRENCY', pattern: '"$"#,##0.00' } },
- *    { numberFormat: { type: 'NUMBER', pattern: '#,##0.00' } } ]
- *  rows: [                                                                  // rows contains the values for 2nd row ahead
- *    {                                                                      // Each row object has:
- *      cols: {                                                                  // cols - map header -> (value | stringValue)
- *        'Header 1': { value: 'row 1 text', stringValue: 'row 1 text' },
- *        'Header 2': { value: 0.41, stringValue: '$0.41' },
- *        'Header 3': { value: 3, stringValue: '3.00' }
- *       },
- *       values: ['row 1 text', 0.41, 3],                                        // values - array with values for each header
- *       stringValue: ['row 1 text', '$0.41', '3.00']                            // stringValue - string representation of the values for each header
- *     },
- *    { ... },
- *    { ... }
- *  ]
- * }
- *
- * Sample access to the value of col 'Header 2' of first row:
- * ```
- * const currencyValue = table.rows[0].cols['Header 2'].value     // 0.41
- * ```
- *
- * It is also possible to get an array with all the (column) values for the row (formatted and string versions):
- * ```
- * const rowValues = table.rows[0].values              // ['row 1 text', 0.41, 3]
- * const rowValues = table.rows[0].stringValues        // ['row 1 text', '$0.41', '3.00']
- * ```
- *
- *
- * Note: Formats are retrieved from first data row.
+ * Converter from google sheet format to node-sheets format
  */
 function sheetToTable (sheet) {
   if (sheet.data.length === 0 || sheet.data[0].rowData === undefined) {
@@ -205,16 +188,16 @@ function sheetToTable (sheet) {
 
   const otherRows = gridData.rowData.slice(1)
 
+  const values = otherRows.length > 0 ? otherRows[0].values : new Array(headers.length).fill({})
+
   return {
     title: sheet.properties.title,
     headers: headers,
-    formats: otherRows[0].values.map(value => effectiveFormat(value)),
-    rows: otherRows.map(row => ({
-      cols: zipObject(headers,
-                      row.values.map(value => ({ value: effectiveValue(value), stringValue: formattedValue(value)}))),
-      values: row.values.map(value => effectiveValue(value)),
-      stringValues: row.values.map(value => formattedValue(value))
-    }))
+    formats: values.map(value => effectiveFormat(value)),
+    rows: otherRows.map(row => zipObject(
+      headers,
+      row.values.map(value => ({ value: effectiveValue(value), stringValue: formattedValue(value)}))
+    ))
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -79,7 +79,7 @@ describe('Sheets', function () {
       const gs = new Sheets(SPREADSHEET_TEST_ID)
       await gs.authorizeApiKey(SPREADSHEET_API_KEY)
       const names = await gs.getSheetsNames()
-      const tables = await gs.tables(names.map(name => `${name}!A:ZZZ`))
+      const tables = await gs.tables(names.map(name => ({name: name})))
       //console.log(util.inspect(tables, { depth: null, colors: true }))
       assert.equal(tables.length, names.length)
       assert.deepEqual(tables.map(t => t.title), names)
@@ -91,24 +91,24 @@ describe('Sheets', function () {
     })
   })
 
-  describe('#table (Formats!A1:E3)', () => {
+  describe('#tables (Formats!A1:E3)', () => {
     const gs = new Sheets(SPREADSHEET_TEST_ID)
     before(async () => {
       await gs.authorizeApiKey(SPREADSHEET_API_KEY)
     })
 
     it('should return formatted tabular spreadsheet data', async () => {
-      const table = await gs.table('Formats!A1:E3')
+      const table = await gs.tables('Formats!A1:E3')
       // console.log(util.inspect(table, { depth: null, colors: true }))
       assert.deepEqual(table.headers, [ 'Automatic', 'Currency', 'Date', 'Number', 'Plain Text' ])
       assert.deepEqual(table.formats.map(f => f.numberFormat.type), [ 'NONE', 'CURRENCY', 'DATE', 'NUMBER', 'TEXT' ])
       assert.equal(table.rows.length, 2)
-      assert.deepEqual(Object.keys(table.rows[0].cols), ['Automatic', 'Currency', 'Date', 'Number', 'Plain Text' ])
-      assert.deepEqual(table.rows[0].cols['Automatic'], { value: 'Oil', stringValue: 'Oil' })
-      assert.deepEqual(table.rows[0].cols['Currency'], { value: 0.41, stringValue: '$0.41' })
-      assert.deepEqual(table.rows[0].cols['Date'], { value: new Date(2016, 0, 25), stringValue: '1/25/2016' })
-      assert.deepEqual(table.rows[0].cols['Number'], { value: 123, stringValue: '123.00' })
-      assert.deepEqual(table.rows[0].cols['Plain Text'], { value: 'This is some text', stringValue: 'This is some text' })
+      assert.deepEqual(Object.keys(table.rows[0]), ['Automatic', 'Currency', 'Date', 'Number', 'Plain Text' ])
+      assert.deepEqual(table.rows[0]['Automatic'], { value: 'Oil', stringValue: 'Oil' })
+      assert.deepEqual(table.rows[0]['Currency'], { value: 0.41, stringValue: '$0.41' })
+      assert.deepEqual(table.rows[0]['Date'], { value: new Date(2016, 0, 25), stringValue: '1/25/2016' })
+      assert.deepEqual(table.rows[0]['Number'], { value: 123, stringValue: '123.00' })
+      assert.deepEqual(table.rows[0]['Plain Text'], { value: 'This is some text', stringValue: 'This is some text' })
     })
 
     it('should return formatted tabular (tableCols) spreadsheet data', async () => {
@@ -116,7 +116,6 @@ describe('Sheets', function () {
       assert.equal(cols.length, 5)
       assert.deepEqual(cols.map(c => c.header), [ 'Automatic', 'Currency', 'Date', 'Number', 'Plain Text' ])
       assert.equal(cols[0].header, 'Automatic')
-      assert.deepEqual(cols[0].values, ['Oil', 'Grass'])
     })
   })
 
@@ -127,21 +126,28 @@ describe('Sheets', function () {
     })
 
     it('should retrieve only cols and rows with content (8 cols and 2 rows - from "Class Data")', async () => {
-      const table = await gs.table('Class Data')
+      const table = await gs.tables('Class Data')
       assert.equal(table.headers.length, 8)
       assert.equal(table.rows.length, 2)
       // console.log(util.inspect(table, { depth: null, colors: true, breakLength: Infinity }))
     })
 
+    it('should use named range instead of sheet name for special names', async () => {
+      const table = await gs.tables('A02')
+      // console.log(util.inspect(table, { depth: null, colors: true, breakLength: Infinity }))
+      assert.equal(table.rows.length, 0)
+      assert.equal(table.headers.length, 1)
+      assert.equal(table.headers[0], 'Thomas')
+    })
+
     it('should retrieve empty cells as undefined (5 cols and 3 rows - from "Table with empty cells")', async () => {
-      const table = await gs.table('Table with empty cells')
+      const table = await gs.tables('Table with empty cells')
       // console.log(util.inspect(table, { depth: null, colors: true, breakLength: Infinity }))
       assert.equal(table.headers.length, 5)
       assert.equal(table.rows.length, 3)
-      assert.deepEqual(table.rows[1].values, ['Andrew', undefined, '1. Freshman', 'SD', 'Math'])
-      assert.deepEqual(table.rows[2].values, ['Anna', 'Female', undefined, undefined, 'English'])
+      assert.deepEqual(Object.keys(table.rows[1]).map(col => table.rows[1][col].value), ['Andrew', undefined, '1. Freshman', 'SD', 'Math'])
+      assert.deepEqual(Object.keys(table.rows[2]).map(col => table.rows[2][col].value), ['Anna', 'Female', undefined, undefined, 'English'])
     })
-
   })
 
   describe('works with Promises', () => {
@@ -156,7 +162,7 @@ describe('Sheets', function () {
       const gs = new Sheets(SPREADSHEET_TEST_ID)
       const authData = SPREADSHEET_JWT_KEY
       gs.authorizeJWT(authData)
-        .then(() => gs.table('Formats!A1:E3'))
+        .then(() => gs.tables('Formats!A1:E3'))
         .then(table => {
           assert.notEqual(table.headers, null)
           assert.notEqual(table.formats, null)


### PR DESCRIPTION
@mderazon please give a look at this PR.

I've improved the response of `.table(...)` to include a hash by column name in the rows (see example bellow), and also the method `.tables(ranges)` that accepts and array with ranges and returns an array of table objects.

Note the use of `!A:ZZZ` in the test scenario. I don't know if we should "auto append" this in the lib to the calls without "!..." part in the sheet name. What do you think? 

| Header 1   | Header 2 | Header 3 |
| ---------- | -------- | -------- |
| row 1 text | $0.41    | 3.00     |
| ...        | ...      | ...      |

```javascript
const table = await gs.table('Formats')

{
 title: 'Formats',                                                        // name of the sheet/table
 headers: ['Header 1', 'Header 2', 'Header 3'],                           // name of the headers (1st row)
 formats: [                                                               // array with information regarding cell format
   { numberFormat: { type: 'NONE' } },
   { numberFormat: { type: 'CURRENCY', pattern: '"$"#,##0.00' } },
   { numberFormat: { type: 'NUMBER', pattern: '#,##0.00' } } ]
 rows: [                                                                  // rows contains the values for 2nd row ahead
   {                                                                      // Each row object has:
     cols: {                                                                  // cols - map header -> (value | stringValue)
       'Header 1': { value: 'row 1 text', stringValue: 'row 1 text' },
       'Header 2': { value: 0.41, stringValue: '$0.41' },
       'Header 3': { value: 3, stringValue: '3.00' }
      },
      values: ['row 1 text', 0.41, 3],                                        // values - array with values for each header
      stringValue: ['row 1 text', '$0.41', '3.00']                            // stringValue - string representation of the values for each header
    },
   { ... },
   { ... }
 ]
}
```

related with urbancups/node-sheets#5 and urbancups/node-sheets#7